### PR TITLE
Update the badge website due to a broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Otherwise, you are free to continue...
 
 **You can win a badge for completing this game!**
 
-learn more about badges here: https://openbadgefactory.com/faq
+learn more about badges here: https://openbadgefactory.com
 
 **You should always check the README.md file for your next clue!**
 


### PR DESCRIPTION
The page "https://openbadgefactory.com/faq" mentioned in the file
README.md is not found, so the "/faq" was removed.